### PR TITLE
update for game version 1.20 - itemtype attempt 2

### DIFF
--- a/Swordz 1.1.8/assets/swordz/itemtypes/axes/beardedaxe.json
+++ b/Swordz 1.1.8/assets/swordz/itemtypes/axes/beardedaxe.json
@@ -25,7 +25,7 @@
 			selectionBox: { x1: 0, y1: 0, z1: 0, x2: 1, y2: 0.1, z2: 1 },
 			collisionBox: { x1: 0, y1: 0, z1: 0, x2: 0, y2: 0, z2: 0 },
 		}
-	}],
+	}, { name: "AnimationAuthoritative" }],
 	variantgroups: [ { code: "metal", states: ["tinbronze","bismuthbronze","iron","meteoriciron","steel"]}, ],
 	shape: { base: "axes/bearded" },
 	heldTpHitAnimation: "zweiswing",

--- a/Swordz 1.1.8/assets/swordz/itemtypes/axes/daneaxe.json
+++ b/Swordz 1.1.8/assets/swordz/itemtypes/axes/daneaxe.json
@@ -25,7 +25,7 @@
 			selectionBox: { x1: 0, y1: 0, z1: 0, x2: 1, y2: 0.1, z2: 1 },
 			collisionBox: { x1: 0, y1: 0, z1: 0, x2: 0, y2: 0, z2: 0 },
 		}
-	}],
+	}, { name: "AnimationAuthoritative" }],
 	variantgroups: [ { code: "metal", states: ["iron","meteoriciron","steel"]}, ],
 	shape: { base: "axes/daneaxe" },
 	heldTpHitAnimation: "zweiswing",

--- a/Swordz 1.1.8/assets/swordz/itemtypes/clubs/nadziak.json
+++ b/Swordz 1.1.8/assets/swordz/itemtypes/clubs/nadziak.json
@@ -26,7 +26,7 @@
 			selectionBox: { x1: 0, y1: 0, z1: 0, x2: 1, y2: 0.1, z2: 1 },
 			collisionBox: { x1: 0, y1: 0, z1: 0, x2: 0, y2: 0, z2: 0 },
 		}
-	}],
+	}, { name: "AnimationAuthoritative" }],
 	variantgroups: [ 
 	{ code: "metal", states: ["bismuthbronze","tinbronze","blackbronze","iron","meteoriciron","steel"]},
 //	{ code: "haft", states: ["bismuthbronze","tinbronze","blackbronze","iron","meteoriciron","steel"]},	

--- a/Swordz 1.1.8/assets/swordz/itemtypes/clubs/padded.json
+++ b/Swordz 1.1.8/assets/swordz/itemtypes/clubs/padded.json
@@ -1,7 +1,6 @@
 {
 	code: "padded",
-	damagedby: ["attacking"],
-	class: "ItemSword",
+	damagedby: [ "attacking" ],
 	tool: "sword",
 	attributes: {
 		handbook: { groupBy: ["padded"] },
@@ -26,7 +25,7 @@
 			selectionBox: { x1: 0, y1: 0, z1: 0, x2: 1, y2: 0.1, z2: 1 },
 			collisionBox: { x1: 0, y1: 0, z1: 0, x2: 0, y2: 0, z2: 0 },
 		}
-	}],
+	}, { name: "AnimationAuthoritative" }],
 	shape: { base: "clubs/padded" },
 	heldTpHitAnimation: "falx",
 	attackRange: 2,

--- a/Swordz 1.1.8/assets/swordz/itemtypes/clubs/pernach.json
+++ b/Swordz 1.1.8/assets/swordz/itemtypes/clubs/pernach.json
@@ -1,7 +1,6 @@
 {
 	code: "pernach",
 	damagedby: ["attacking"],
-	class: "ItemSword",
 	tool: "sword",
 	attributes: {
 		handbook: { groupBy: ["pernach"] },
@@ -25,7 +24,7 @@
 			selectionBox: { x1: 0, y1: 0, z1: 0, x2: 1, y2: 0.1, z2: 1 },
 			collisionBox: { x1: 0, y1: 0, z1: 0, x2: 0, y2: 0, z2: 0 },
 		}
-	}],
+	}, { name: "AnimationAuthoritative" }],
 	variantgroups: [ 
 	{ code: "metal", states: ["lead","copper","bismuthbronze","tinbronze","blackbronze","iron","meteoriciron","steel"]},
 	{ code: "haft", states: ["copper","bismuthbronze","tinbronze","blackbronze","iron","meteoriciron","steel"]},

--- a/Swordz 1.1.8/assets/swordz/itemtypes/clubs/warhammer.json
+++ b/Swordz 1.1.8/assets/swordz/itemtypes/clubs/warhammer.json
@@ -1,7 +1,6 @@
 {
 	code: "warhammer",
 	damagedby: ["attacking"],
-	class: "ItemSword",
 	tool: "sword",
 	attributes: {
 		handbook: { groupBy: ["warhammer-*"] },
@@ -25,7 +24,7 @@
 			selectionBox: { x1: 0, y1: 0, z1: 0, x2: 1, y2: 0.1, z2: 1 },
 			collisionBox: { x1: 0, y1: 0, z1: 0, x2: 0, y2: 0, z2: 0 },
 		}
-	}],
+	}, { name: "AnimationAuthoritative" }],
 	variantgroups: [ 
 	{ code: "metal", states: ["bismuthbronze","tinbronze","blackbronze","iron","meteoriciron","steel"]},
 //	{ code: "haft", states: ["bismuthbronze","tinbronze","blackbronze","iron","meteoriciron","steel"]},	

--- a/Swordz 1.1.8/assets/swordz/itemtypes/knives/seax.json
+++ b/Swordz 1.1.8/assets/swordz/itemtypes/knives/seax.json
@@ -26,7 +26,7 @@
 			selectionBox: { x1: 0, y1: 0, z1: 0, x2: 1, y2: 0.1, z2: 1 },
 			collisionBox: { x1: 0, y1: 0, z1: 0, x2: 0, y2: 0, z2: 0 },
 		}
-	}],
+	},{ name: "AnimationAuthoritative" }],
 	variantgroups: [ { code: "metal", states: ["copper","bismuthbronze","tinbronze","iron","meteoriciron","steel"]}, ],
 	shape: { base: "knives/seax" },
 //	animation of "breaktool" ?

--- a/Swordz 1.1.8/assets/swordz/itemtypes/knives/stiletto.json
+++ b/Swordz 1.1.8/assets/swordz/itemtypes/knives/stiletto.json
@@ -1,7 +1,6 @@
 {
 	code: "stiletto",
 	damagedby: ["attacking"],
-	class: "ItemSword",
 	tool: "sword",
 	attributes: {
 		handbook: { groupBy: ["stiletto"] },
@@ -26,7 +25,7 @@
 			selectionBox: { x1: 0, y1: 0, z1: 0, x2: 1, y2: 0.1, z2: 1 },
 			collisionBox: { x1: 0, y1: 0, z1: 0, x2: 0, y2: 0, z2: 0 },
 		}
-	}],
+	}, { name: "AnimationAuthoritative" }],
 	variantgroups: [ { code: "metal", states: ["copper","bismuthbronze","tinbronze","iron","meteoriciron","steel"]}, ],
 	shape: { base: "knives/stiletto" },
 	heldTpHitAnimation: "spearhit",

--- a/Swordz 1.1.8/assets/swordz/itemtypes/polearms/atgeir.json
+++ b/Swordz 1.1.8/assets/swordz/itemtypes/polearms/atgeir.json
@@ -1,7 +1,6 @@
 {
 	code: "atgeir",
 	damagedby: ["attacking"],
-	class: "ItemSword",
 	tool: "spear",
 	attributes: {
 		handbook: { groupBy: ["atgeir"] },
@@ -25,7 +24,7 @@
 			selectionBox: { x1: 0, y1: 0, z1: 0, x2: 1, y2: 0.1, z2: 1 },
 			collisionBox: { x1: 0, y1: 0, z1: 0, x2: 0, y2: 0, z2: 0 },
 		}
-	}],
+	}, { name: "AnimationAuthoritative" }],
 	variantgroups: [ { code: "metal", states: ["iron","meteoriciron","steel"]}, ],
 	shape: { base: "polearms/atgeir2" },
 	heldTpHitAnimation: "polearmswing",

--- a/Swordz 1.1.8/assets/swordz/itemtypes/polearms/becdecorbin.json
+++ b/Swordz 1.1.8/assets/swordz/itemtypes/polearms/becdecorbin.json
@@ -1,7 +1,6 @@
 {
 	code: "becdecorbin",
 	damagedby: ["attacking"],
-	class: "ItemSword",
 	tool: "spear",
 	attributes: {
 		handbook: { groupBy: ["becdecorbin"] },
@@ -25,7 +24,7 @@
 			selectionBox: { x1: 0, y1: 0, z1: 0, x2: 1, y2: 0.1, z2: 1 },
 			collisionBox: { x1: 0, y1: 0, z1: 0, x2: 0, y2: 0, z2: 0 },
 		}
-	}],
+	}, { name: "AnimationAuthoritative" }],
 	variantgroups: [ { code: "metal", states: ["iron","meteoriciron","steel"]}, ],
 	shape: { base: "polearms/becdecorbin" },
 	heldTpHitAnimation: "polearmswing",

--- a/Swordz 1.1.8/assets/swordz/itemtypes/polearms/boarspear.json
+++ b/Swordz 1.1.8/assets/swordz/itemtypes/polearms/boarspear.json
@@ -1,7 +1,6 @@
 {
 	code: "boarspear",
 	damagedby: ["attacking"],
-	class: "ItemSword",
 	tool: "spear",
 	attributes: {
 		handbook: { groupBy: ["boarspear"] },
@@ -26,7 +25,7 @@
 			selectionBox: { x1: 0, y1: 0, z1: 0, x2: 1, y2: 0.1, z2: 1 },
 			collisionBox: { x1: 0, y1: 0, z1: 0, x2: 0, y2: 0, z2: 0 },
 		}
-	}],
+	}, { name: "AnimationAuthoritative" }],
 	variantgroups: [ { code: "metal", states: ["iron","meteoriciron","steel"]}, ],
 	shape: { base: "polearms/boarspear" },
 	heldTpHitAnimation: "spearhit",

--- a/Swordz 1.1.8/assets/swordz/itemtypes/polearms/halberd.json
+++ b/Swordz 1.1.8/assets/swordz/itemtypes/polearms/halberd.json
@@ -1,7 +1,6 @@
 {
 	code: "halberd",
 	damagedby: ["attacking"],
-	class: "ItemSword",
 	tool: "spear",
 	attributes: {
 		handbook: { groupBy: ["halberd"] },
@@ -26,7 +25,7 @@
 			selectionBox: { x1: 0, y1: 0, z1: 0, x2: 1, y2: 0.1, z2: 1 },
 			collisionBox: { x1: 0, y1: 0, z1: 0, x2: 0, y2: 0, z2: 0 },
 		}
-	}],
+	}, { name: "AnimationAuthoritative" }],
 	variantgroups: [ { code: "metal", states: ["iron","meteoriciron","steel"]}, ],
 	shape: { base: "polearms/halberd" },
 	heldTpHitAnimation: "polearmswing",

--- a/Swordz 1.1.8/assets/swordz/itemtypes/polearms/naginata.json
+++ b/Swordz 1.1.8/assets/swordz/itemtypes/polearms/naginata.json
@@ -1,7 +1,6 @@
 {	enabled:false,
 	code: "naginata",
 	damagedby: ["attacking"],
-	class: "ItemSword",
 	tool: "spear",
 	attributes: {
 		handbook: { groupBy: ["naginata"] },
@@ -25,7 +24,7 @@
 			selectionBox: { x1: 0, y1: 0, z1: 0, x2: 1, y2: 0.1, z2: 1 },
 			collisionBox: { x1: 0, y1: 0, z1: 0, x2: 0, y2: 0, z2: 0 },
 		}
-	}],
+	}, { name: "AnimationAuthoritative" }],
 	variantgroups: [ { code: "metal", states: ["iron","meteoriciron","steel"]}, ],
 	shape: { base: "polearms/naginata" },
 	heldTpHitAnimation: "polearmswing",

--- a/Swordz 1.1.8/assets/swordz/itemtypes/polearms/pollaxe.json
+++ b/Swordz 1.1.8/assets/swordz/itemtypes/polearms/pollaxe.json
@@ -1,7 +1,6 @@
 {
 	code: "pollaxe",
 	damagedby: ["attacking"],
-	class: "ItemSword",
 	tool: "spear",
 	attributes: {
 		handbook: { groupBy: ["pollaxe"] },
@@ -26,7 +25,7 @@
 			selectionBox: { x1: 0, y1: 0, z1: 0, x2: 1, y2: 0.1, z2: 1 },
 			collisionBox: { x1: 0, y1: 0, z1: 0, x2: 0, y2: 0, z2: 0 },
 		}
-	}],
+	}, { name: "AnimationAuthoritative" }],
 	variantgroups: [ { code: "metal", states: ["iron","meteoriciron","steel"]}, ],
 	shape: { base: "polearms/pollaxe" },
 	heldTpHitAnimation: "polearmswing",

--- a/Swordz 1.1.8/assets/swordz/itemtypes/polearms/ranseur.json
+++ b/Swordz 1.1.8/assets/swordz/itemtypes/polearms/ranseur.json
@@ -1,7 +1,6 @@
 {
 	code: "ranseur",
 	damagedby: ["attacking"],
-	class: "ItemSword",
 	tool: "spear",
 	attributes: {
 		handbook: { groupBy: ["ranseur"] },
@@ -26,7 +25,7 @@
 			selectionBox: { x1: 0, y1: 0, z1: 0, x2: 1, y2: 0.1, z2: 1 },
 			collisionBox: { x1: 0, y1: 0, z1: 0, x2: 0, y2: 0, z2: 0 },
 		}
-	}],
+	}, { name: "AnimationAuthoritative" }],
 	variantgroups: [ { code: "metal", states: ["iron","meteoriciron","steel"]}, ],
 	shape: { base: "game:item/tool/spear/ranseur" },
 	heldTpHitAnimation: "spearhit",

--- a/Swordz 1.1.8/assets/swordz/itemtypes/polearms/voulge.json
+++ b/Swordz 1.1.8/assets/swordz/itemtypes/polearms/voulge.json
@@ -1,7 +1,6 @@
 {
 	code: "voulge",
 	damagedby: ["attacking"],
-	class: "ItemSword",
 	tool: "spear",
 	attributes: {
 		handbook: { groupBy: ["voulge"] },
@@ -25,7 +24,7 @@
 			selectionBox: { x1: 0, y1: 0, z1: 0, x2: 1, y2: 0.1, z2: 1 },
 			collisionBox: { x1: 0, y1: 0, z1: 0, x2: 0, y2: 0, z2: 0 },
 		}
-	}],
+	}, { name: "AnimationAuthoritative" }],
 	variantgroups: [ { code: "metal", states: ["iron","meteoriciron","steel"]}, ],
 	shape: { base: "polearms/voulge" },
 	heldTpHitAnimation: "polearmswing",

--- a/Swordz 1.1.8/assets/swordz/itemtypes/polearms/warscythe.json
+++ b/Swordz 1.1.8/assets/swordz/itemtypes/polearms/warscythe.json
@@ -1,7 +1,6 @@
 {
 	code: "warscythe",
 	damagedby: ["attacking"],
-	class: "ItemSword",
 	tool: "spear",
 	attributes: {
 		handbook: { groupBy: ["warscythe"] },
@@ -25,7 +24,7 @@
 			selectionBox: { x1: 0, y1: 0, z1: 0, x2: 1, y2: 0.1, z2: 1 },
 			collisionBox: { x1: 0, y1: 0, z1: 0, x2: 0, y2: 0, z2: 0 },
 		}
-	}],
+	}, { name: "AnimationAuthoritative" }],
 	variantgroups: [ { code: "metal", states: ["copper","tinbronze","bismuthbronze","blackbronze","iron","meteoriciron","steel"]}, ],
 	shape: { base: "polearms/warscythe" },
 	heldTpHitAnimation: "polearmswing",

--- a/Swordz 1.1.8/assets/swordz/itemtypes/swords/armingsword.json
+++ b/Swordz 1.1.8/assets/swordz/itemtypes/swords/armingsword.json
@@ -1,7 +1,6 @@
 {
 	code: "sord",
 	damagedby: ["attacking"],
-	class: "ItemSword",
 	tool: "sword",
 	attributes: {
 		handbook: { groupBy: ["sord"] },
@@ -25,7 +24,7 @@
 			selectionBox: { x1: 0, y1: 0, z1: 0, x2: 1, y2: 0.1, z2: 1 },
 			collisionBox: { x1: 0, y1: 0, z1: 0, x2: 0, y2: 0, z2: 0 },
 		}
-	}],
+	}, { name: "AnimationAuthoritative" }],
 	variantgroups: [ 
 	{ code: "metal", states: ["tinbronze","iron","meteoriciron","steel"]}, 
 	{ code: "sharpness", states: ["blunt","dull","sharp","honed"]},

--- a/Swordz 1.1.8/assets/swordz/itemtypes/swords/gladius.json
+++ b/Swordz 1.1.8/assets/swordz/itemtypes/swords/gladius.json
@@ -1,7 +1,6 @@
 {
 	code: "gladius",
 	damagedby: ["attacking"],
-	class: "ItemSword",
 	tool: "sword",
 	attributes: {
 		handbook: { groupBy: ["gladius"] },
@@ -25,7 +24,7 @@
 			selectionBox: { x1: 0, y1: 0, z1: 0, x2: 1, y2: 0.1, z2: 1 },
 			collisionBox: { x1: 0, y1: 0, z1: 0, x2: 0, y2: 0, z2: 0 },
 		}
-	}],
+	}, { name: "AnimationAuthoritative" }],
 	variantgroups: [ 
 	{ code: "metal", states: ["iron"]},
 	{ code: "sharpness", states: ["blunt","dull","sharp","honed"]},

--- a/Swordz 1.1.8/assets/swordz/itemtypes/swords/khopesh.json
+++ b/Swordz 1.1.8/assets/swordz/itemtypes/swords/khopesh.json
@@ -1,7 +1,6 @@
 {	enabled:false,
 	code: "khopesh",
-	damagedby: ["attacking"],
-	class: "ItemSword",
+	damagedby: [ "attacking" ],
 	tool: "sword",
 	attributes: {
 		handbook: { groupBy: ["khopesh"] },
@@ -25,7 +24,7 @@
 			selectionBox: { x1: 0, y1: 0, z1: 0, x2: 1, y2: 0.1, z2: 1 },
 			collisionBox: { x1: 0, y1: 0, z1: 0, x2: 0, y2: 0, z2: 0 },
 		}
-	}],
+	}, { name: "AnimationAuthoritative" }],
 	variantgroups: [ 
 	{ code: "metal", states: ["copper","tinbronze","bismuthbronze","blackbronze"]},
 	{ code: "sharpness", states: ["blunt","dull","sharp","honed"]},

--- a/Swordz 1.1.8/assets/swordz/itemtypes/swords/killij.json
+++ b/Swordz 1.1.8/assets/swordz/itemtypes/swords/killij.json
@@ -1,7 +1,6 @@
 {
 	code: "kilij",
 	damagedby: ["attacking"],
-	class: "ItemSword",
 	tool: "sword",
 	attributes: {
 		handbook: { groupBy: ["kilij"] },
@@ -25,7 +24,7 @@
 			selectionBox: { x1: 0, y1: 0, z1: 0, x2: 1, y2: 0.1, z2: 1 },
 			collisionBox: { x1: 0, y1: 0, z1: 0, x2: 0, y2: 0, z2: 0 },
 		}
-	}],
+	}, { name: "AnimationAuthoritative" }],
 	variantgroups: [ 
 	{ code: "metal", states: ["iron","meteoriciron","steel"]},
 	{ code: "sharpness", states: ["blunt","dull","sharp","honed"]},

--- a/Swordz 1.1.8/assets/swordz/itemtypes/swords/longsword.json
+++ b/Swordz 1.1.8/assets/swordz/itemtypes/swords/longsword.json
@@ -1,7 +1,6 @@
 {
 	code: "longsword",
 	damagedby: ["attacking"],
-	class: "ItemSword",
 	tool: "sword",
 	attributes: {
 		handbook: { groupBy: ["longsword"] },
@@ -25,7 +24,7 @@
 			selectionBox: { x1: 0, y1: 0, z1: 0, x2: 1, y2: 0.1, z2: 1 },
 			collisionBox: { x1: 0, y1: 0, z1: 0, x2: 0, y2: 0, z2: 0 },
 		}
-	}],
+	}, { name: "AnimationAuthoritative" }],
 	variantgroups: [ 
 	{ code: "metal", states: ["iron","meteoriciron","steel"]}, 
 	{ code: "sharpness", states: ["blunt","dull","sharp","honed"]},

--- a/Swordz 1.1.8/assets/swordz/itemtypes/swords/sabre.json
+++ b/Swordz 1.1.8/assets/swordz/itemtypes/swords/sabre.json
@@ -1,7 +1,6 @@
 {
 	code: "sabre",
 	damagedby: ["attacking"],
-	class: "ItemSword",
 	tool: "sword",
 	attributes: {
 		handbook: { groupBy: ["sabre"] },
@@ -25,7 +24,7 @@
 			selectionBox: { x1: 0, y1: 0, z1: 0, x2: 1, y2: 0.1, z2: 1 },
 			collisionBox: { x1: 0, y1: 0, z1: 0, x2: 0, y2: 0, z2: 0 },
 		}
-	}],
+	}, { name: "AnimationAuthoritative" }],
 	variantgroups: [ 
 	{ code: "metal", states: ["iron","meteoriciron","steel"]},
 	{ code: "sharpness", states: ["blunt","dull","sharp","honed"]},

--- a/Swordz 1.1.8/assets/swordz/itemtypes/swords/spatha.json
+++ b/Swordz 1.1.8/assets/swordz/itemtypes/swords/spatha.json
@@ -1,7 +1,6 @@
 {
 	code: "spatha",
 	damagedby: ["attacking"],
-	class: "ItemSword",
 	tool: "sword",
 	attributes: {
 		handbook: { groupBy: ["spatha"] },
@@ -25,7 +24,7 @@
 			selectionBox: { x1: 0, y1: 0, z1: 0, x2: 1, y2: 0.1, z2: 1 },
 			collisionBox: { x1: 0, y1: 0, z1: 0, x2: 0, y2: 0, z2: 0 },
 		}
-	}],
+	}, { name: "AnimationAuthoritative" }],
 	variantgroups: [ 
 	{ code: "metal", states: ["steel"]},
 	{ code: "sharpness", states: ["blunt","dull","sharp","honed"]},

--- a/Swordz 1.1.8/assets/swordz/itemtypes/swords/zweihander.json
+++ b/Swordz 1.1.8/assets/swordz/itemtypes/swords/zweihander.json
@@ -1,7 +1,6 @@
 {
 	code: "zweihander",
 	damagedby: ["attacking"],
-	class: "ItemSword",
 	tool: "sword",
 	attributes: {
 		handbook: { groupBy: ["zweihander"] },
@@ -26,7 +25,7 @@
 			selectionBox: { x1: 0, y1: 0, z1: 0, x2: 1, y2: 0.1, z2: 1 },
 			collisionBox: { x1: 0, y1: 0, z1: 0, x2: 0, y2: 0, z2: 0 },
 		}
-	}],
+	}, { name: "AnimationAuthoritative" }],
 	variantgroups: [ 
 	{ code: "metal", states: ["iron","meteoriciron","steel"]},
 	{ code: "cgm", states: ["silver","gold","iron","meteoriciron","steel"]},


### PR DESCRIPTION
removed "class:itemSword" from all weapons that had it as that seems to be removed from the base game and was causing lots of errors to appear in the log when loading into a world. 
all the weapons have had animationauthorative added to them so that the attacks are linked to the animation timing. Tools have not had this done to them.

fixed the seax not doing any damage


closed previous pull request since this one would have all the updates the previous one would have